### PR TITLE
Fix responses usage

### DIFF
--- a/test/test_rest.py
+++ b/test/test_rest.py
@@ -35,73 +35,66 @@ def env_qradar_console_fqdn():
 
 @responses.activate
 def test_rest_uses_env_vars_when_set(env_sec_admin_token, env_qradar_console_fqdn):
-    with responses.RequestsMock() as responses_mock:
-        responses_mock.add('GET', 'https://9.101.234.169/testing_endpoint', status=200)
-        response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
-        assert response.status_code == 200
-        assert responses_mock.calls[0].request.method == 'GET'
-        assert responses_mock.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
-        assert responses_mock.calls[0].request.headers['SEC'] == '12345-testing-12345-testing'
+    responses.add('GET', 'https://9.101.234.169/testing_endpoint', status=200)
+    response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
+    assert response.status_code == 200
+    assert responses.calls[0].request.method == 'GET'
+    assert responses.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
+    assert responses.calls[0].request.headers['SEC'] == '12345-testing-12345-testing'
 
 @responses.activate
 def test_rest_uses_sec_cookie_when_env_var_not_set(env_qradar_console_fqdn):
     test_sec_cookie_value = 'seccookie-12345-seccookie'
     cookie = http.dump_cookie("SEC", test_sec_cookie_value)
     app = Flask(__name__)
-    with responses.RequestsMock() as responses_mock:
-        with app.test_request_context(headers={"COOKIE": cookie}):
-            responses_mock.add('GET', 'https://9.101.234.169/testing_endpoint', status=200)
-            response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
-            assert response.status_code == 200
-            assert responses_mock.calls[0].request.method == 'GET'
-            assert responses_mock.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
-            assert responses_mock.calls[0].request.headers['SEC'] == test_sec_cookie_value
+    with app.test_request_context(headers={"COOKIE": cookie}):
+        responses.add('GET', 'https://9.101.234.169/testing_endpoint', status=200)
+        response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
+        assert response.status_code == 200
+        assert responses.calls[0].request.method == 'GET'
+        assert responses.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
+        assert responses.calls[0].request.headers['SEC'] == test_sec_cookie_value
 
 @responses.activate
 def test_rest_uses_manifest_console_ip_when_env_var_not_set():
-    with responses.RequestsMock() as responses_mock:
-        responses_mock.add('GET', 'https://9.123.321.101/testing_endpoint', status=200)
-        response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
-        assert response.status_code == 200
-        assert responses_mock.calls[0].request.method == 'GET'
-        assert responses_mock.calls[0].request.url == 'https://9.123.321.101/testing_endpoint'
+    responses.add('GET', 'https://9.123.321.101/testing_endpoint', status=200)
+    response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
+    assert response.status_code == 200
+    assert responses.calls[0].request.method == 'GET'
+    assert responses.calls[0].request.url == 'https://9.123.321.101/testing_endpoint'
 
 @responses.activate
 def test_rest_sets_version_header(env_qradar_console_fqdn):
-    with responses.RequestsMock() as responses_mock:
-        responses_mock.add('GET', 'https://9.101.234.169/testing_endpoint', status=200)
-        response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert', version='12')
-        assert response.status_code == 200
-        assert responses_mock.calls[0].request.method == 'GET'
-        assert responses_mock.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
-        assert responses_mock.calls[0].request.headers['Version'] == '12'
+    responses.add('GET', 'https://9.101.234.169/testing_endpoint', status=200)
+    response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert', version='12')
+    assert response.status_code == 200
+    assert responses.calls[0].request.method == 'GET'
+    assert responses.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
+    assert responses.calls[0].request.headers['Version'] == '12'
 
 @responses.activate
 def test_rest_allows_post(env_qradar_console_fqdn):
-    with responses.RequestsMock() as responses_mock:
-        responses_mock.add('POST', 'https://9.101.234.169/testing_endpoint', status=201)
-        response = qpylib.REST('POST', 'testing_endpoint', verify='dummycert')
-        assert response.status_code == 201
-        assert responses_mock.calls[0].request.method == 'POST'
-        assert responses_mock.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
+    responses.add('POST', 'https://9.101.234.169/testing_endpoint', status=201)
+    response = qpylib.REST('POST', 'testing_endpoint', verify='dummycert')
+    assert response.status_code == 201
+    assert responses.calls[0].request.method == 'POST'
+    assert responses.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
 
 @responses.activate
 def test_rest_allows_put(env_qradar_console_fqdn):
-    with responses.RequestsMock() as responses_mock:
-        responses_mock.add('PUT', 'https://9.101.234.169/testing_endpoint', status=201)
-        response = qpylib.REST('PUT', 'testing_endpoint', verify='dummycert')
-        assert response.status_code == 201
-        assert responses_mock.calls[0].request.method == 'PUT'
-        assert responses_mock.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
+    responses.add('PUT', 'https://9.101.234.169/testing_endpoint', status=201)
+    response = qpylib.REST('PUT', 'testing_endpoint', verify='dummycert')
+    assert response.status_code == 201
+    assert responses.calls[0].request.method == 'PUT'
+    assert responses.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
 
 @responses.activate
 def test_rest_allows_delete(env_qradar_console_fqdn):
-    with responses.RequestsMock() as responses_mock:
-        responses_mock.add('DELETE', 'https://9.101.234.169/testing_endpoint', status=204)
-        response = qpylib.REST('DELETE', 'testing_endpoint', verify='dummycert')
-        assert response.status_code == 204
-        assert responses_mock.calls[0].request.method == 'DELETE'
-        assert responses_mock.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
+    responses.add('DELETE', 'https://9.101.234.169/testing_endpoint', status=204)
+    response = qpylib.REST('DELETE', 'testing_endpoint', verify='dummycert')
+    assert response.status_code == 204
+    assert responses.calls[0].request.method == 'DELETE'
+    assert responses.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
 
 def test_rest_rejects_unsupported_method(env_qradar_console_fqdn):
     with pytest.raises(ValueError, match='Unsupported REST action was requested'):

--- a/test/test_sdk_qpylib.py
+++ b/test/test_sdk_qpylib.py
@@ -21,11 +21,10 @@ def pre_testing_setup():
 @patch('qpylib.sdk_qpylib.SdkQpylib.get_console_address', return_value = '9.101.234.169')
 @patch('qpylib.sdk_qpylib.SdkQpylib._get_api_auth', return_value = ('testuser', 'testing123'))
 def test_rest_uses_input_values(mock_api_auth, mock_console_address):
-    with responses.RequestsMock() as responses_mock:
-        responses_mock.add('GET', 'https://9.101.234.169/testing_endpoint',
-                           json={'success': True}, status=200)
+    responses.add('GET', 'https://9.101.234.169/testing_endpoint',
+                       json={'success': True}, status=200)
 
-        response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
-        assert responses_mock.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
-        assert 'Basic' in responses_mock.calls[0].request.headers['Authorization']
-        assert response.status_code == 200
+    response = qpylib.REST('GET', 'testing_endpoint', verify='dummycert')
+    assert responses.calls[0].request.url == 'https://9.101.234.169/testing_endpoint'
+    assert 'Basic' in responses.calls[0].request.headers['Authorization']
+    assert response.status_code == 200


### PR DESCRIPTION
Due to my incorrect eclipse config, the use of responses in the unit tests was wrong. Fixed now.