### PR TITLE
Standardize how package version is managed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ build
 dist
 qpylib.egg-info
 RemoteSystemsTempFiles
-VERSION
+qpylib/version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
-include LICENSE VERSION
+include LICENSE
+exclude MANIFEST.in
 prune test

--- a/build.sh
+++ b/build.sh
@@ -5,5 +5,5 @@
 
 QPYLIB_VERSION=${1:-dev}
 echo "Building qpylib version ${QPYLIB_VERSION}"
-echo ${QPYLIB_VERSION} > VERSION
+echo "__version__ = '${QPYLIB_VERSION}'" > qpylib/version.py
 python setup.py sdist

--- a/clean.sh
+++ b/clean.sh
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-rm -f VERSION
+rm -rf .pytest_cache
+rm -f qpylib/version.py
 rm -rf dist qpylib.egg-info
 rm -rf qpylib/__pycache__
 rm -rf "test/__pycache__"

--- a/qpylib/__init__.py
+++ b/qpylib/__init__.py
@@ -3,4 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 __author__ = 'IBM'
-__version__ = '1.0'
+__version__ = 'unknown'
+try:
+    from .version import __version__
+except ImportError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 import setuptools
 
 def main():
-    with open("VERSION", "r") as version_file:
-        version = version_file.read().rstrip()
+    with open("qpylib/version.py", "r") as version_file:
+        line = version_file.read().rstrip()
+        _, _, version = line.replace("'", '').split()
 
     with open("README.md", "r") as readme:
         long_desc = readme.read()


### PR DESCRIPTION
Version "truth" is in a single file which is generated at build time. Previously this was called "VERSION". Now moved to qpylib/version.py so that it is available in these places:
- setup.py for distribution packaging
- __init__.py for runtime import.