### PR TITLE
Updates to work with PyCryptoDome (dropin for PyCrypto)

### DIFF
--- a/qpylib/encdec.py
+++ b/qpylib/encdec.py
@@ -98,7 +98,7 @@ class Encryption(object):
             self.config[self.name]['ivz'].encode('utf-8'),
             segment_size=128)
         clear_text_padded_string = self.__pad_string(clear_text_string)
-        encrypted_bytes = aes.encrypt(clear_text_padded_string)
+        encrypted_bytes = aes.encrypt(clear_text_padded_string.encode("utf8"))
         encrypted_hex_bytes = b2a_hex(encrypted_bytes).rstrip()
         return encrypted_hex_bytes.decode('utf-8')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ flask
 requests
 cryptography
 pyOpenSSL
-pycrypto
+pycryptodome
 pylint
 responses


### PR DESCRIPTION
Should resolve #11 

Only one change needed to be made to the source code based on my testing. All Encdec test cases pass. 
This encoding change does **not** appear to be backwards compatible with pycrypto

pycryptodome should be syntactically the same as pycrypto. The import statements are even the same. 
Unsure if the requirements file is the only place this should be updated. 

As an FYI, Pycryptodome**x** is an equivalent library under a separate namespace, useful if the functionality of pycrypto and crypto are both needed.  