### PR TITLE
Don't allow SonarQube to run on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 script: 
   - ./lint.sh && ./test.sh
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -z "$TRAVIS_TAG" ]; then sonar-scanner; fi # sonar only on non-PRs
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_REPO_SLUG" == "ibm/qpylib"]; then sonar-scanner; fi # sonar only on non-PRs
 
 after_success:
   - if [[ $TRAVIS_TAG ]]; then


### PR DESCRIPTION
Previously builds failed on forks but this will allow builds to run on forks.