### PR TITLE
[fix] null char and empty/whitespace string

### DIFF
--- a/qpylib/encdec.py
+++ b/qpylib/encdec.py
@@ -122,10 +122,6 @@ class Encryption(object):
 
     def encrypt(self, clear_text):
         """ Encrypts a clear text secret """
-        if clear_text.strip(' \t\n\r') == '':
-            qpylib.log('encdec : encrypt : Unable to encrypt an empty string')
-            return str('')
-
         try:
             self.config[self.name]['version'] = Encryption.engine_version
             self.config[self.name]['secret'] = self.__encrypt_string(clear_text)

--- a/qpylib/encdec.py
+++ b/qpylib/encdec.py
@@ -7,6 +7,9 @@ import json
 import os
 import string
 import uuid
+
+from Crypto.Util.Padding import pad, unpad
+
 from . import qpylib
 
 from Crypto.Random import random
@@ -99,8 +102,8 @@ class Encryption(object):
             AES.MODE_CFB,
             self.config[self.name]['ivz'].encode('utf-8'),
             segment_size=128)
-        clear_text_padded_string = self.__pad_string(clear_text_string)
-        encrypted_bytes = aes.encrypt(clear_text_padded_string.encode("utf8"))
+        clear_text_padded_string = pad(clear_text_string.encode('utf-8'), AES.block_size)
+        encrypted_bytes = aes.encrypt(clear_text_padded_string)
         encrypted_hex_bytes = b2a_hex(encrypted_bytes).rstrip()
         return encrypted_hex_bytes.decode('utf-8')
 
@@ -114,21 +117,8 @@ class Encryption(object):
             segment_size=128)
         encrypted_hex_bytes = encrypted_string.encode('utf-8')
         encrypted_bytes = a2b_hex(encrypted_hex_bytes)
-        decrypted_bytes = aes.decrypt(encrypted_bytes)
-        clear_text_padded_string = decrypted_bytes.decode('utf-8')
-        return self.__unpad_string(clear_text_padded_string)
-
-    def __pad_string(self, value):
-        """ Adds padding to the string so that the resulting length is a multiple of 16 """
-        length = len(value)
-        pad_size = 16 - (length % 16)
-        return value.ljust(length + pad_size, '\x00')
-
-    def __unpad_string(self, value):
-        """ Removes the added padding from the string """
-        while value[-1] == '\x00':
-            value = value[:-1]
-        return value
+        decrypted_bytes = unpad(aes.decrypt(encrypted_bytes), AES.block_size)
+        return decrypted_bytes.decode('utf-8')
 
     def encrypt(self, clear_text):
         """ Encrypts a clear text secret """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+testpaths = test

--- a/test/test_endec.py
+++ b/test/test_endec.py
@@ -131,6 +131,6 @@ def test_decrypt_raise_value_error_on_engine_version_mismatch(set_unset_qradar_a
 def test_encrypt_decrypt_null_char(set_unset_qradar_app_uuid_env_var,
                                    patch_get_store_path, repeatable_encrypt):
     enc_string = repeatable_encrypt.encrypt('\x00')
-    assert enc_string == 'cd09251dde83002c7d426a3d065a89bb'
+    assert enc_string == 'cd062a12d18c0f23724d6532095586b4'
     dec_string = repeatable_encrypt.decrypt()
     assert dec_string == '\x00'

--- a/test/test_endec.py
+++ b/test/test_endec.py
@@ -65,11 +65,6 @@ def test_encrypt_creates_valid_config_on_start(set_unset_qradar_app_uuid_env_var
     Encryption({"name": "test_name", "user": "test_user"})
     assert os.path.isfile(DB_STORE)
 
-def test_encryption_returns_empty_string_encrypting_empty_string(set_unset_qradar_app_uuid_env_var,
-                                                                 patch_get_store_path):
-    enc = Encryption({"name": "test_name", "user": "test_user"})
-    assert enc.encrypt('') == ''
-
 def test_encryption_stores_encrypted_secret_in_config(set_unset_qradar_app_uuid_env_var,
                                                       patch_get_store_path):
     enc = Encryption({"name": "test_name", "user": "test_user"})

--- a/test/test_endec.py
+++ b/test/test_endec.py
@@ -141,3 +141,10 @@ def test_encrypt_decrypt_empty_string(set_unset_qradar_app_uuid_env_var,
     assert enc_string == 'dd19350dce93103c6d527a2d164a99ab'
     dec_string = repeatable_encrypt.decrypt()
     assert dec_string == ''
+
+def test_encrypt_decrypt_whitespace(set_unset_qradar_app_uuid_env_var,
+                                      patch_get_store_path, repeatable_encrypt):
+    enc_string = repeatable_encrypt.encrypt('  \n \t ')
+    assert enc_string == 'ed292f3dd7a30a26774860370c5083b1'
+    dec_string = repeatable_encrypt.decrypt()
+    assert dec_string == '  \n \t '

--- a/test/test_endec.py
+++ b/test/test_endec.py
@@ -134,3 +134,10 @@ def test_encrypt_decrypt_null_char(set_unset_qradar_app_uuid_env_var,
     assert enc_string == 'cd062a12d18c0f23724d6532095586b4'
     dec_string = repeatable_encrypt.decrypt()
     assert dec_string == '\x00'
+
+def test_encrypt_decrypt_empty_string(set_unset_qradar_app_uuid_env_var,
+                                      patch_get_store_path, repeatable_encrypt):
+    enc_string = repeatable_encrypt.encrypt('')
+    assert enc_string == 'dd19350dce93103c6d527a2d164a99ab'
+    dec_string = repeatable_encrypt.decrypt()
+    assert dec_string == ''


### PR DESCRIPTION
- The previous custom padding scheme was not always reversible if the secret contained null characters. Use Crypto.utils pad/unpad (PKCS padding) instead which is reversible.
  - This change is **not** compatible, but I did not rev the engine version because I was told we're the first to use the new version
- Remove logic for not encrypting empty/whitespace strings as it is not necessary and they are still valid secrets