### PR TITLE
Fix SonarCloud addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ python: 3.7.2
 
 addons:
   sonarcloud:
-    token:
-      secure: "${SONAR_CLOUD_TOKEN}"
+      organisation: "qradar-app-framework"
 
 script: 
   - ./lint.sh && ./test.sh
     # sonar scan skipped if build was triggered by create pull request or create tag or fork build.
-#  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_REPO_SLUG" == "IBM/qpylib" ]; then
-#      sonar-scanner;
-#    fi
+    # this will only run once merged into the qpylib repository - not on forks/pull requests
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_REPO_SLUG" == "IBM/qpylib" ]; then
+      sonar-scanner;
+    fi
 
 after_success:
   - if [[ $TRAVIS_TAG ]]; then


### PR DESCRIPTION
This fixes the SonarCloud addon syntax, and enables SonarCloud scans again.

The SONAR_CLOUD_TOKEN which was previously supplied with the 'secure' syntax is now replaced by SONAR_TOKEN; which is directly consumed by the SonarCloud addon.

Successful test run can be found here:
https://travis-ci.com/github/jthomperoo/qpylib/builds/175885739
