### PR TITLE
Make SyslogHandler RFC5424 compliant

### DIFF
--- a/qpylib/log_qpylib.py
+++ b/qpylib/log_qpylib.py
@@ -33,7 +33,8 @@ def create_log():
         if util_qpylib.is_ipv6_address(console_ip):
             console_ip = console_ip[1:-1]
         syslog_handler = SysLogHandler(address=(console_ip, 514))
-        syslog_handler.setFormatter(logging.Formatter(SYSLOG_APP_LOG_FORMAT.replace('[app_id]', str(app_id)), "%Y-%m-%dT%H:%M:%S%z"))
+        syslog_app_format = SYSLOG_APP_LOG_FORMAT.replace('[app_id]', str(app_id))
+        syslog_handler.setFormatter(logging.Formatter(syslog_app_format, "%Y-%m-%dT%H:%M:%S%z"))
         QLOGGER.addHandler(syslog_handler)
 
 def set_log_level(level='INFO'):

--- a/qpylib/log_qpylib.py
+++ b/qpylib/log_qpylib.py
@@ -9,6 +9,7 @@ from . import util_qpylib
 
 APP_FILE_LOG_FORMAT = '%(asctime)s [%(module)s.%(funcName)s] [%(threadName)s] [%(levelname)s] - %(message)s'
 APP_CONSOLE_LOG_FORMAT = '%(asctime)s %(module)s.%(funcName)s: %(message)s'
+SYSLOG_APP_LOG_FORMAT = '1 %(asctime)s [app_id] %(message)s'
 
 QLOGGER = 0
 
@@ -28,10 +29,11 @@ def create_log():
 
     if not util_qpylib.is_sdk():
         console_ip = app_qpylib.get_console_ip()
+        app_id = app_qpylib.get_app_id()
         if util_qpylib.is_ipv6_address(console_ip):
             console_ip = console_ip[1:-1]
         syslog_handler = SysLogHandler(address=(console_ip, 514))
-        syslog_handler.setFormatter(logging.Formatter(APP_CONSOLE_LOG_FORMAT))
+        syslog_handler.setFormatter(logging.Formatter(SYSLOG_APP_LOG_FORMAT.replace('[app_id]', str(app_id)), "%Y-%m-%dT%H:%M:%S%z"))
         QLOGGER.addHandler(syslog_handler)
 
 def set_log_level(level='INFO'):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -8,9 +8,9 @@ from unittest.mock import patch
 import logging
 from logging.handlers import RotatingFileHandler, SysLogHandler
 import os
+import datetime
 import pytest
 from qpylib import qpylib, log_qpylib
-import datetime
 
 APP_FILE_LOG_FORMAT = '[{0}] - [APP_ID/1001][NOT:{1}] {2}'
 
@@ -19,9 +19,9 @@ MANIFEST_JSON_ROOT_PATH = 'qpylib.app_qpylib.get_root_path'
 def manifest_path(manifest_file):
     return os.path.join(os.path.dirname(__file__), 'manifests', manifest_file)
 
-def validate_date(text, format):
+def validate_date(text, fmt):
     try:
-        datetime.datetime.strptime(text, format)
+        datetime.datetime.strptime(text, fmt)
         return True
     except ValueError:
         return False


### PR DESCRIPTION
Changed the format of the Syslog hander to make it RFC 5424 compliant and added a test case.

In the discussion for this issue [https://github.com/IBM/qpylib/issues/30](https://github.com/IBM/qpylib/issues/30) the app name is suggested in place of a hostname, I used the app ID instead to ensure only ASCII characters are used.

The test case might look a bit weird, it works like this:

- I couldn't find a way to test the Syslog output with pytest, so for the duration of this test it replaces the formatter for the existing log file handler with the new Syslog one.
- A log is then sent, it's format is checked to ensure it's RFC 5424 compliant
- The test case then replaces the formatter for the log file handler with it's original one ensuring the test has no side effects