### PR TITLE
Refactor log handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The qpylib library hosted here is for use only with apps that have been written 
 Python 3 to run on Red Hat Universal Base Image. It is not compatible with apps
 written to run on a CentOS base image.
 
+Most functions are the equivalent of their pre-Github counterparts, although
+there may be some small differences in parameter names.
+
 ## Project details
 
 * [LICENSE](LICENSE)

--- a/qpylib/encryption/cryptoutil.py
+++ b/qpylib/encryption/cryptoutil.py
@@ -1,0 +1,15 @@
+# Copyright 2019 IBM Corporation All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+def derive_key(key_material, salt, iterations=100000, length=32):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(),
+                     length=length,
+                     salt=salt,
+                     iterations=iterations,
+                     backend=default_backend())
+    return kdf.derive(key_material)

--- a/qpylib/encryption/enginev4.py
+++ b/qpylib/encryption/enginev4.py
@@ -6,9 +6,7 @@ import base64
 import string
 import secrets
 from cryptography.fernet import Fernet
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from . import cryptoutil
 
 class Enginev4():
     ''' Enginev4 uses Fernet encryption.
@@ -30,14 +28,9 @@ class Enginev4():
         return decrypted_bytes.decode('utf-8')
 
     def _derive_key(self):
-        kdf = PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=32,
-            salt=self.config['salt'].encode('utf-8'),
-            iterations=self.config['iterations'],
-            backend=default_backend()
-        )
-        key = kdf.derive(self.app_uuid.encode('utf-8'))
+        key = cryptoutil.derive_key(self.app_uuid.encode('utf-8'),
+                                    self.config['salt'].encode('utf-8'),
+                                    self.config['iterations'])
         return base64.urlsafe_b64encode(key)
 
     @staticmethod

--- a/qpylib/log_qpylib.py
+++ b/qpylib/log_qpylib.py
@@ -4,74 +4,139 @@
 
 import logging
 from logging.handlers import RotatingFileHandler, SysLogHandler
-from . import app_qpylib
-from . import util_qpylib
+import re
+import socket
+from . import app_qpylib, util_qpylib
 
-APP_FILE_LOG_FORMAT = '%(asctime)s [%(module)s.%(funcName)s] [%(threadName)s] [%(levelname)s] - %(message)s'
-APP_CONSOLE_LOG_FORMAT = '%(asctime)s %(module)s.%(funcName)s: %(message)s'
+# Log format for local file logging.
+# Uses default date/time formatting from logging module.
+# Before the logging formatter is created, APPID is substituted with the actual app ID,
+# which is constant for all logs generated within an app container.
+# Example: 2020-08-19 12:48:11,423 [Thread-4] [INFO] [APP_ID:1005] [NOT:0000006000] hello
 
-QLOGGER = 0
+APP_FILE_LOG_FORMAT = '%(asctime)s [%(threadName)s] [%(levelname)s] [APP_ID:APPID] [NOT:%(ncode)s] %(message)s'
 
-def log(message, level):
-    log_fn = _choose_log_fn(level)
-    log_fn("[APP_ID/{0}][NOT:{1}] {2}"
-           .format(app_qpylib.get_app_id(), _map_notification_code(level), message))
+# Log format for Syslog.
+# See https://tools.ietf.org/html/rfc5424 for more details on the following specification:
+# SYSLOG-MSG = HEADER SP STRUCTURED-DATA SP MSG
+# HEADER = PRI VERSION SP TIMESTAMP SP HOSTNAME SP APPNAME SP PROCID SP MSGID
+# PRI is taken care of by SysLogHandler and not included in the log format below.
+# VERSION is hard-coded to 1.
+# TIMESTAMP in the specification is e.g. 2020-04-12T19:20:50.345678+01:00
+#   For the seconds fraction, %f is not supported in "time" module, which is what the logging
+#   module uses. Instead, SYSLOG_LOG_FORMAT uses asctime and msecs plus SYSLOG_TIME_FORMAT.
+#   This means the UTC offset (%z) cannot be included, so timestamps will look like this:
+#     2020-04-12T19:20:50.345
+# HOSTNAME is set to the container IP address.
+# APPNAME is set to a sanitised copy of the app manifest name field.
+# PROCID is set to the app ID.
+#   HOSTNAME, APPNAME and PROCID are all constants, replaced in the format string with their values.
+# MSGID and STRUCTURED-DATA are set to the Syslog nil value '-'.
+# Example: 1 2020-08-21T14:16:51.812 192.168.0.15 MyExampleApp 1005 - - [NOT:0000006000] hello
+
+SYSLOG_LOG_FORMAT = '1 %(asctime)s.%(msecs)d HOSTNAME APPNAME PROCID - - [NOT:%(ncode)s] %(message)s'
+SYSLOG_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+
+# Globals related to logging.Logger instance.
+QLOGGER = None
+LOG_LEVEL_TO_FUNCTION = None
 
 def create_log():
     global QLOGGER
     QLOGGER = logging.getLogger('com.ibm.applicationLogger')
-    QLOGGER.setLevel(default_log_level())
+    QLOGGER.setLevel(_default_log_level())
+    QLOGGER.addFilter(NotificationCodeFilter())
+    _add_handlers()
 
-    handler = RotatingFileHandler(_log_file_location(), maxBytes=2*1024*1024, backupCount=5)
-    handler.setFormatter(logging.Formatter(APP_FILE_LOG_FORMAT))
-    QLOGGER.addHandler(handler)
-
-    if not util_qpylib.is_sdk():
-        console_ip = app_qpylib.get_console_ip()
-        if util_qpylib.is_ipv6_address(console_ip):
-            console_ip = console_ip[1:-1]
-        syslog_handler = SysLogHandler(address=(console_ip, 514))
-        syslog_handler.setFormatter(logging.Formatter(APP_CONSOLE_LOG_FORMAT))
-        QLOGGER.addHandler(syslog_handler)
-
-def set_log_level(level='INFO'):
-    global QLOGGER
-    QLOGGER.setLevel(_map_log_level(level))
-
-def default_log_level():
-    return _map_log_level(app_qpylib.get_manifest_field_value('log_level', 'INFO'))
-
-def _log_file_location():
-    return app_qpylib.get_log_path('app.log')
-
-def _choose_log_fn(level):
-    global QLOGGER
-    if QLOGGER == 0:
-        raise RuntimeError('You cannot use log before logging has been initialised')
-    return {
-        'INFO': QLOGGER.info,
+    global LOG_LEVEL_TO_FUNCTION
+    LOG_LEVEL_TO_FUNCTION = {
         'DEBUG': QLOGGER.debug,
+        'INFO': QLOGGER.info,
         'WARNING': QLOGGER.warning,
         'ERROR': QLOGGER.error,
         'EXCEPTION': QLOGGER.exception,
         'CRITICAL': QLOGGER.critical
-    }.get(level.upper(), QLOGGER.info)
+    }
 
-def _map_notification_code(level):
-    return {
-        'INFO': "0000006000",
-        'DEBUG': "0000006000",
-        'WARNING': "0000004000",
-        'ERROR': "0000003000",
-        'EXCEPTION': "0000003000",
-        'CRITICAL': "0000003000"
-    }.get(level.upper(), "0000006000")
+def log(message, level):
+    global LOG_LEVEL_TO_FUNCTION
+    if not LOG_LEVEL_TO_FUNCTION:
+        raise RuntimeError('You cannot use log before logging has been initialised')
+    log_function = LOG_LEVEL_TO_FUNCTION.get(level.upper())
+    if not log_function:
+        raise ValueError("Unknown level: '{0}'".format(level))
+    log_function(message)
 
-def _map_log_level(level):
-    return {
-        'INFO': logging.INFO,
-        'DEBUG': logging.DEBUG,
-        'WARNING': logging.WARNING,
-        'ERROR': logging.ERROR,
-        'CRITICAL': logging.CRITICAL
-    }.get(level.upper(), logging.INFO)
+def set_log_level(level='INFO'):
+    global QLOGGER
+    if not QLOGGER:
+        raise RuntimeError('You cannot use set_log_level before logging has been initialised')
+    QLOGGER.setLevel(level.upper())
+
+def _default_log_level():
+    return app_qpylib.get_manifest_field_value('log_level', 'INFO').upper()
+
+def _log_file_location():
+    return app_qpylib.get_log_path('app.log')
+
+def _add_handlers():
+    global QLOGGER
+    app_id = str(app_qpylib.get_app_id())
+    QLOGGER.addHandler(_create_file_handler(app_id))
+    if not util_qpylib.is_sdk():
+        QLOGGER.addHandler(_create_syslog_handler(app_id))
+
+def _create_file_handler(app_id):
+    handler = RotatingFileHandler(_log_file_location(), maxBytes=2*1024*1024, backupCount=5)
+    log_format = APP_FILE_LOG_FORMAT.replace('APPID', app_id)
+    handler.setFormatter(logging.Formatter(log_format))
+    return handler
+
+def _create_syslog_handler(app_id):
+    handler = SysLogHandler(address=_get_address_for_syslog())
+    log_format = _create_syslog_log_format(app_id)
+    handler.setFormatter(logging.Formatter(log_format, SYSLOG_TIME_FORMAT))
+    return handler
+
+def _create_syslog_log_format(app_id):
+    return SYSLOG_LOG_FORMAT.replace('HOSTNAME', _get_container_ip()) \
+                            .replace('APPNAME', _create_sanitized_app_name()) \
+                            .replace('PROCID', app_id)
+
+def _get_address_for_syslog():
+    console_ip = app_qpylib.get_console_ip()
+    if util_qpylib.is_ipv6_address(console_ip):
+        console_ip = console_ip[1:-1]
+    return (console_ip, 514)
+
+def _get_container_ip():
+    return socket.gethostbyname(socket.gethostname())
+
+def _create_sanitized_app_name():
+    ''' Extracts app name from manifest, strips unwanted characters,
+        and truncates to max length 48, as per RFC5424.
+    '''
+    return re.sub(r'\W+', '', app_qpylib.get_app_name())[:48]
+
+class NotificationCodeFilter(logging.Filter):
+    ''' Filter which adds a field named ncode to each log record.
+        Allows notification code to be specified in log handler
+        format strings.
+    '''
+    # These are standard QRadar codes for identifying log levels.
+    Q_INFO_CODE = '0000006000'
+    Q_WARNING_CODE = '0000004000'
+    Q_ERROR_CODE = '0000003000'
+
+    def filter(self, record):
+        record.ncode = self._log_level_to_notification_code.get(
+            record.levelname.upper(), self.Q_INFO_CODE)
+        return True
+
+    _log_level_to_notification_code = {
+        'DEBUG': Q_INFO_CODE,
+        'INFO': Q_INFO_CODE,
+        'WARNING': Q_WARNING_CODE,
+        'ERROR': Q_ERROR_CODE,
+        'CRITICAL': Q_ERROR_CODE
+    }

--- a/qpylib/qpylib.py
+++ b/qpylib/qpylib.py
@@ -17,8 +17,8 @@ def create_log():
         Threshold log level is set to the value of the "log_level" field
         in the app manifest.json, or INFO if that field is absent.
         Creates a file log handler which directs logs to store/log/app.log.
-        Creates a Syslog handler, but only if environment variable
-        QRADAR_CONSOLE_IP is set.
+        Creates a Syslog handler, but only if environment variables
+        QRADAR_CONSOLE_IP and QRADAR_APP_UUID are both set.
         Must be called before any call to log() or set_log_level().
         Raises ValueError if the manifest threshold log level is invalid.
     '''

--- a/qpylib/qpylib.py
+++ b/qpylib/qpylib.py
@@ -14,21 +14,27 @@ from . import util_qpylib
 
 def log(message, level='INFO'):
     ''' Logs a message at the given level, which defaults to INFO.
-        Level values: DEBUG, INFO, WARNING, ERROR, CRITICAL.
+        Level values: DEBUG, INFO, WARNING, ERROR, EXCEPTION, CRITICAL.
+        EXCEPTION is ERROR plus extra exception details.
         Raises RuntimeError if logging was not previously initialised
         by a call to qpylib.create_log().
+        Raises ValueError if level is invalid.
     '''
     log_qpylib.log(message, level)
 
 def create_log():
-    ''' Initialises logging with INFO as the threshold log level.
-        Must be called before any call to qpylib.log().
+    ''' Initialises logging with threshold log level set to the value
+        of the "log_level" field in the app manifest.json, or INFO if
+        that field is absent.
+        Must be called before any call to log() or set_log_level().
+        Raises ValueError if the threshold log level is invalid.
     '''
     log_qpylib.create_log()
 
 def set_log_level(level):
     ''' Sets the threshold log level.
         Level values: DEBUG, INFO, WARNING, ERROR, CRITICAL.
+        Raises ValueError if level is invalid.
     '''
     log_qpylib.set_log_level(level)
 

--- a/qpylib/qpylib.py
+++ b/qpylib/qpylib.py
@@ -12,6 +12,18 @@ from . import util_qpylib
 
 # ==== Logging ====
 
+def create_log():
+    ''' Initialises logging.
+        Threshold log level is set to the value of the "log_level" field
+        in the app manifest.json, or INFO if that field is absent.
+        Creates a file log handler which directs logs to store/log/app.log.
+        Creates a Syslog handler, but only if environment variable
+        QRADAR_CONSOLE_IP is set.
+        Must be called before any call to log() or set_log_level().
+        Raises ValueError if the manifest threshold log level is invalid.
+    '''
+    log_qpylib.create_log()
+
 def log(message, level='INFO'):
     ''' Logs a message at the given level, which defaults to INFO.
         Level values: DEBUG, INFO, WARNING, ERROR, EXCEPTION, CRITICAL.
@@ -22,18 +34,11 @@ def log(message, level='INFO'):
     '''
     log_qpylib.log(message, level)
 
-def create_log():
-    ''' Initialises logging with threshold log level set to the value
-        of the "log_level" field in the app manifest.json, or INFO if
-        that field is absent.
-        Must be called before any call to log() or set_log_level().
-        Raises ValueError if the threshold log level is invalid.
-    '''
-    log_qpylib.create_log()
-
 def set_log_level(level):
     ''' Sets the threshold log level.
         Level values: DEBUG, INFO, WARNING, ERROR, CRITICAL.
+        Raises RuntimeError if logging was not previously initialised
+        by a call to qpylib.create_log().
         Raises ValueError if level is invalid.
     '''
     log_qpylib.set_log_level(level)

--- a/qpylib/util_qpylib.py
+++ b/qpylib/util_qpylib.py
@@ -3,9 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import socket
 
 def is_sdk():
     return os.getenv('QRADAR_APPFW_SDK', 'no').lower() == 'true'
 
 def is_ipv6_address(ip_address):
     return ip_address.startswith('[') and ip_address.endswith(']')
+
+def get_container_ip():
+    return socket.gethostbyname(socket.gethostname())

--- a/qpylib/util_qpylib.py
+++ b/qpylib/util_qpylib.py
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import socket
 
 def is_sdk():
     return os.getenv('QRADAR_APPFW_SDK', 'no').lower() == 'true'
 
 def is_ipv6_address(ip_address):
     return ip_address.startswith('[') and ip_address.endswith(']')
-
-def get_container_ip():
-    return socket.gethostbyname(socket.gethostname())

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -2,53 +2,50 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# pylint: disable=redefined-outer-name, unused-argument, invalid-name
+# pylint: disable=redefined-outer-name, unused-argument, invalid-name, protected-access
 
 from unittest.mock import patch
 import logging
 from logging.handlers import RotatingFileHandler, SysLogHandler
 import os
 import pytest
-from qpylib import qpylib, log_qpylib
+from qpylib import qpylib, log_qpylib, app_qpylib
 
-APP_FILE_LOG_FORMAT = '[{0}] - [APP_ID/1001][NOT:{1}] {2}'
+@pytest.fixture(scope='function', autouse=True)
+def reset_globals():
+    app_qpylib.Q_CACHED_MANIFEST = None
+    if log_qpylib.QLOGGER:
+        log_qpylib.QLOGGER.handlers.clear()
+    log_qpylib.QLOGGER = None
+    log_qpylib.LOG_LEVEL_TO_FUNCTION = None
 
-MANIFEST_JSON_ROOT_PATH = 'qpylib.app_qpylib.get_root_path'
-
-def manifest_path(manifest_file):
-    return os.path.join(os.path.dirname(__file__), 'manifests', manifest_file)
-
-# This fixture avoids reading app id from the manifest.
-# Setting default log level threshold is handled by separate fixtures.
 @pytest.fixture(scope='module', autouse=True)
-def bypass_manifest_lookup():
-    with patch('qpylib.app_qpylib.get_app_id') as mock_get_app_id:
-        mock_get_app_id.return_value = 1001
-        yield
+def env_app_id():
+    os.environ['QRADAR_APP_ID'] = '1001'
+    yield
+    del os.environ['QRADAR_APP_ID']
 
+# Threshold fixtures are used to control logger.setLevel in create_log().
 @pytest.fixture(scope='function')
 def info_threshold():
-    with patch('qpylib.log_qpylib.default_log_level') as mock_default_log_level:
+    with patch('qpylib.log_qpylib._default_log_level') as mock_default_log_level:
         mock_default_log_level.return_value = logging.INFO
         yield
 
 @pytest.fixture(scope='function')
 def debug_threshold():
-    with patch('qpylib.log_qpylib.default_log_level') as mock_default_log_level:
+    with patch('qpylib.log_qpylib._default_log_level') as mock_default_log_level:
         mock_default_log_level.return_value = logging.DEBUG
         yield
 
+# Use this fixture to avoid instantiation of SysLogHandler.
 @pytest.fixture(scope='function')
-def set_console_ip():
-    os.environ['QRADAR_CONSOLE_IP'] = '9.123.234.101'
+def env_is_sdk():
+    os.environ['QRADAR_APPFW_SDK'] = 'true'
     yield
-    del os.environ['QRADAR_CONSOLE_IP']
+    del os.environ['QRADAR_APPFW_SDK']
 
-@pytest.fixture(scope='function')
-def set_console_ipv6():
-    os.environ['QRADAR_CONSOLE_IP'] = '[9.123.234.101]'
-    yield
-    del os.environ['QRADAR_CONSOLE_IP']
+# ==== _log_file_location ====
 
 @pytest.fixture(scope='function')
 def env_app_root():
@@ -56,72 +53,160 @@ def env_app_root():
     yield
     del os.environ['APP_ROOT']
 
-@pytest.fixture(scope='function', autouse=True)
-def reset_globals():
-    qpylib.app_qpylib.Q_CACHED_MANIFEST = None
-    if qpylib.log_qpylib.QLOGGER != 0:
-        qpylib.log_qpylib.QLOGGER.handlers.clear()
-
-# pylint: disable=protected-access
-def verify_log_file_content(log_path, expected_lines, not_expected_lines=[]): # pylint: disable=dangerous-default-value
-    with open(log_path) as log_file:
-        content = log_file.read()
-        for line in expected_lines:
-            assert APP_FILE_LOG_FORMAT.format(
-                line['level'], log_qpylib._map_notification_code(line['level']), line['text']) in content
-        for line in not_expected_lines:
-            assert APP_FILE_LOG_FORMAT.format(
-                line['level'], log_qpylib._map_notification_code(line['level']), line['text']) not in content
-
 def test_log_file_location(env_app_root):
     assert log_qpylib._log_file_location() == '/opt/app-root/store/log/app.log'
 
-def test_log_without_create_raises_error():
-    with pytest.raises(RuntimeError, match='You cannot use log before logging has been initialised'):
-        qpylib.log('hello')
+# ==== _default_log_level ====
 
-def test_create_log_without_console_ip_env_var_raises_error(info_threshold, tmpdir):
+MANIFEST_JSON_ROOT_PATH = 'qpylib.app_qpylib.get_root_path'
+
+def manifest_path(manifest_file):
+    return os.path.join(os.path.dirname(__file__), 'manifests', manifest_file)
+
+@patch(MANIFEST_JSON_ROOT_PATH, return_value=manifest_path('installed.json'))
+def test_default_log_level_no_level_in_manifest_returns_info(mock_manifest):
+    assert log_qpylib._default_log_level() == 'INFO'
+
+@patch(MANIFEST_JSON_ROOT_PATH, return_value=manifest_path('loglevel.json'))
+def test_default_log_level_read_from_manifest(mock_manifest):
+    assert log_qpylib._default_log_level() == 'DEBUG'
+
+# ==== _create_sanitized_app_name ====
+
+GET_APP_NAME = 'qpylib.app_qpylib.get_app_name'
+
+@patch(GET_APP_NAME, return_value='abcz_ABCZ (1234567890) !@£$%^&*+-={}[]:";|\\<>,.?/`~')
+def test_create_sanitized_app_name_strips_invalid_chars(mock_get_app_name):
+    assert log_qpylib._create_sanitized_app_name() == 'abcz_ABCZ1234567890'
+
+@patch(GET_APP_NAME, return_value='MyAppNameIsVeryLongSoThatICanMakeThisTestSucceedByeBye')
+def test_create_sanitized_app_name_truncates_to_48_chars(mock_get_app_name):
+    assert log_qpylib._create_sanitized_app_name() == \
+        'MyAppNameIsVeryLongSoThatICanMakeThisTestSucceed'
+
+# ==== set_log_level ====
+
+def test_set_log_level_without_create_raises_error():
+    with pytest.raises(RuntimeError, match='You cannot use set_log_level before logging has been initialised'):
+        qpylib.set_log_level('DEBUG')
+
+def test_set_log_level_with_bad_level_raises_error(env_is_sdk, info_threshold, tmpdir):
+    log_path = os.path.join(tmpdir.strpath, 'app.log')
+    with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
+        mock_log_location.return_value = log_path
+        qpylib.create_log()
+        with pytest.raises(ValueError, match="Unknown level: 'BAD'"):
+            qpylib.set_log_level('BAD')
+
+def test_set_log_level_sets_correct_level(env_is_sdk, info_threshold, tmpdir):
+    log_path = os.path.join(tmpdir.strpath, 'app.log')
+    with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
+        mock_log_location.return_value = log_path
+        qpylib.create_log()
+    qpylib.set_log_level('DEBUG')
+    assert log_qpylib.QLOGGER.getEffectiveLevel() == logging.DEBUG
+
+# ==== create_log ====
+
+def check_rotating_file_handler_attrs(handler, app_log_path):
+    assert handler.baseFilename == app_log_path
+    assert handler.maxBytes == 2097152
+    assert handler.backupCount == 5
+    assert handler.formatter._fmt == \
+        '%(asctime)s [%(threadName)s] [%(levelname)s] [APP_ID:1001] [NOT:%(ncode)s] %(message)s'
+
+def check_syslog_handler_attrs(handler):
+    assert handler.address[0] == '9.123.234.101'
+    assert handler.address[1] == 514
+    assert handler.formatter._fmt == \
+        '1 %(asctime)s.%(msecs)d 192.168.1.2 LiveManifest 1001 - - [NOT:%(ncode)s] %(message)s'
+    assert handler.formatter.datefmt == log_qpylib.SYSLOG_TIME_FORMAT
+
+def test_create_log_for_syslog_without_console_ip_env_var_raises_error(info_threshold, tmpdir):
     log_path = os.path.join(tmpdir.strpath, 'app.log')
     with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
         mock_log_location.return_value = log_path
         with pytest.raises(KeyError, match='Environment variable QRADAR_CONSOLE_IP is not set'):
             qpylib.create_log()
 
-def check_rotating_file_handler_attrs(handler):
-    assert handler.maxBytes == 2097152
-    assert handler.backupCount == 5
-
-def test_create_log_with_ipv4(set_console_ip, info_threshold, tmpdir):
+def test_create_log_in_sdk(env_is_sdk, info_threshold, tmpdir):
+    app_log_path = os.path.join(tmpdir.strpath, 'app.log')
     with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
-        mock_log_location.return_value = os.path.join(tmpdir.strpath, 'app.log')
+        mock_log_location.return_value = app_log_path
         qpylib.create_log()
-    assert len(qpylib.log_qpylib.QLOGGER.handlers) == 2
-    for handler in qpylib.log_qpylib.QLOGGER.handlers:
-        if isinstance(handler, SysLogHandler):
-            assert handler.address[0] == '9.123.234.101'
-        if isinstance(handler, RotatingFileHandler):
-            check_rotating_file_handler_attrs(handler)
+    assert log_qpylib.QLOGGER.getEffectiveLevel() == logging.INFO
+    assert len(log_qpylib.QLOGGER.handlers) == 1
+    check_rotating_file_handler_attrs(log_qpylib.QLOGGER.handlers[0], app_log_path)
 
-def test_create_log_with_ipv6(set_console_ipv6, info_threshold, tmpdir):
+def run_create_log_with_syslog(log_dir_path):
+    app_log_path = os.path.join(log_dir_path, 'app.log')
     with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
-        mock_log_location.return_value = os.path.join(tmpdir.strpath, 'app.log')
-        qpylib.create_log()
-    assert len(qpylib.log_qpylib.QLOGGER.handlers) == 2
-    for handler in qpylib.log_qpylib.QLOGGER.handlers:
+        mock_log_location.return_value = app_log_path
+        with patch('socket.gethostbyname') as mock_container_ip:
+            mock_container_ip.return_value = '192.168.1.2'
+            qpylib.create_log()
+    assert log_qpylib.QLOGGER.getEffectiveLevel() == logging.INFO
+    assert len(log_qpylib.QLOGGER.handlers) == 2
+    for handler in log_qpylib.QLOGGER.handlers:
         if isinstance(handler, SysLogHandler):
-            assert handler.address[0] == '9.123.234.101'
+            check_syslog_handler_attrs(handler)
         if isinstance(handler, RotatingFileHandler):
-            check_rotating_file_handler_attrs(handler)
+            check_rotating_file_handler_attrs(handler, app_log_path)
+
+@pytest.fixture(scope='function')
+def set_console_ipv4():
+    os.environ['QRADAR_CONSOLE_IP'] = '9.123.234.101'
+    yield
+    del os.environ['QRADAR_CONSOLE_IP']
 
 @patch(MANIFEST_JSON_ROOT_PATH, return_value=manifest_path('installed.json'))
-def test_default_log_level_no_level_in_manifest(mock_manifest, set_console_ip):
-    assert log_qpylib.default_log_level() == logging.INFO
+def test_create_log_with_ipv4_syslog(mock_manifest, set_console_ipv4, info_threshold, tmpdir):
+    run_create_log_with_syslog(tmpdir.strpath)
 
-@patch(MANIFEST_JSON_ROOT_PATH, return_value=manifest_path('loglevel.json'))
-def test_default_log_level_read_from_manifest(mock_manifest, set_console_ip):
-    assert log_qpylib.default_log_level() == logging.DEBUG
+@pytest.fixture(scope='function')
+def set_console_ipv6():
+    os.environ['QRADAR_CONSOLE_IP'] = '[9.123.234.101]'
+    yield
+    del os.environ['QRADAR_CONSOLE_IP']
 
-def test_all_log_levels_with_manifest_info_threshold(set_console_ip, info_threshold, tmpdir):
+@patch(MANIFEST_JSON_ROOT_PATH, return_value=manifest_path('installed.json'))
+def test_create_log_with_ipv6_syslog(mock_manifest, set_console_ipv6, info_threshold, tmpdir):
+    run_create_log_with_syslog(tmpdir.strpath)
+
+# ==== log ====
+
+def test_log_without_create_raises_error():
+    with pytest.raises(RuntimeError, match='You cannot use log before logging has been initialised'):
+        qpylib.log('hello')
+
+def test_log_with_bad_level_raises_error(env_is_sdk, info_threshold, tmpdir):
+    log_path = os.path.join(tmpdir.strpath, 'app.log')
+    with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
+        mock_log_location.return_value = log_path
+        qpylib.create_log()
+        with pytest.raises(ValueError, match="Unknown level: 'BAD'"):
+            qpylib.log('hello', 'BAD')
+
+# Verification of log content is not possible for SysLogHandler, so all of the
+# following tests run in SDK mode and only check RotatingFileHandler output.
+
+APP_FILE_LOG_FORMAT = '[{0}] [APP_ID:1001] [NOT:{1}] {2}'
+
+def level_to_code(level):
+    return log_qpylib.NotificationCodeFilter._log_level_to_notification_code.get(level)
+
+# pylint: disable=dangerous-default-value
+def verify_log_file_content(log_path, expected_lines, not_expected_lines=[]):
+    with open(log_path) as log_file:
+        content = log_file.read()
+        for line in expected_lines:
+            assert APP_FILE_LOG_FORMAT.format(
+                line['level'], level_to_code(line['level']), line['text']) in content
+        for line in not_expected_lines:
+            assert APP_FILE_LOG_FORMAT.format(
+                line['level'], level_to_code(line['level']), line['text']) not in content
+
+def test_all_log_levels_with_manifest_info_threshold(env_is_sdk, info_threshold, tmpdir):
     log_path = os.path.join(tmpdir.strpath, 'app.log')
     with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
         mock_log_location.return_value = log_path
@@ -139,10 +224,10 @@ def test_all_log_levels_with_manifest_info_threshold(set_console_ip, info_thresh
             {'level': 'WARNING', 'text': 'hello warning'},
             {'level': 'ERROR', 'text': 'hello error'},
             {'level': 'CRITICAL', 'text': 'hello critical'},
-            {'level': 'ERROR', 'text': 'hello exception'}],
-                                not_expected_lines=[{'level': 'DEBUG', 'text': 'hello debug'}])
+            {'level': 'ERROR', 'text': 'hello exception'}], \
+            not_expected_lines=[{'level': 'DEBUG', 'text': 'hello debug'}])
 
-def test_all_log_levels_with_manifest_debug_threshold(set_console_ip, debug_threshold, tmpdir):
+def test_all_log_levels_with_manifest_debug_threshold(env_is_sdk, debug_threshold, tmpdir):
     log_path = os.path.join(tmpdir.strpath, 'app.log')
     with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
         mock_log_location.return_value = log_path
@@ -163,7 +248,7 @@ def test_all_log_levels_with_manifest_debug_threshold(set_console_ip, debug_thre
             {'level': 'CRITICAL', 'text': 'hello critical'},
             {'level': 'ERROR', 'text': 'hello exception'}])
 
-def test_all_log_levels_with_set_debug_threshold(set_console_ip, info_threshold, tmpdir):
+def test_all_log_levels_with_set_debug_threshold(env_is_sdk, info_threshold, tmpdir):
     log_path = os.path.join(tmpdir.strpath, 'app.log')
     with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
         mock_log_location.return_value = log_path
@@ -185,7 +270,7 @@ def test_all_log_levels_with_set_debug_threshold(set_console_ip, info_threshold,
             {'level': 'CRITICAL', 'text': 'hello critical'},
             {'level': 'ERROR', 'text': 'hello exception'}])
 
-def test_all_log_levels_with_set_warning_threshold(set_console_ip, info_threshold, tmpdir):
+def test_all_log_levels_with_set_warning_threshold(env_is_sdk, info_threshold, tmpdir):
     log_path = os.path.join(tmpdir.strpath, 'app.log')
     with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
         mock_log_location.return_value = log_path
@@ -202,38 +287,8 @@ def test_all_log_levels_with_set_warning_threshold(set_console_ip, info_threshol
             {'level': 'WARNING', 'text': 'hello warning'},
             {'level': 'ERROR', 'text': 'hello error'},
             {'level': 'CRITICAL', 'text': 'hello critical'},
-            {'level': 'ERROR', 'text': 'hello exception'}],
-                                not_expected_lines=[
-                                    {'level': 'DEBUG', 'text': 'hello debug'},
-                                    {'level': 'INFO', 'text': 'hello default info'},
-                                    {'level': 'INFO', 'text': 'hello info'}])
-
-def test_log_with_bad_level_uses_info(set_console_ip, info_threshold, tmpdir):
-    log_path = os.path.join(tmpdir.strpath, 'app.log')
-    with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
-        mock_log_location.return_value = log_path
-        qpylib.create_log()
-        qpylib.log('hello', 'BAD')
-        verify_log_file_content(log_path, [{'level': 'INFO', 'text': 'hello'}])
-
-def test_set_log_level_with_bad_level_uses_info(set_console_ip, debug_threshold, tmpdir):
-    log_path = os.path.join(tmpdir.strpath, 'app.log')
-    with patch('qpylib.log_qpylib._log_file_location') as mock_log_location:
-        mock_log_location.return_value = log_path
-        qpylib.create_log()
-        qpylib.set_log_level('BAD')
-        qpylib.log('hello debug', 'DEBUG')
-        qpylib.log('hello default info')
-        qpylib.log('hello info', 'INFO')
-        qpylib.log('hello warning', 'WARNING')
-        qpylib.log('hello error', 'ERROR')
-        qpylib.log('hello critical', 'CRITICAL')
-        qpylib.log('hello exception', 'EXCEPTION')
-        verify_log_file_content(log_path, [
-            {'level': 'INFO', 'text': 'hello default info'},
-            {'level': 'INFO', 'text': 'hello info'},
-            {'level': 'WARNING', 'text': 'hello warning'},
-            {'level': 'ERROR', 'text': 'hello error'},
-            {'level': 'CRITICAL', 'text': 'hello critical'},
-            {'level': 'ERROR', 'text': 'hello exception'}],
-                                not_expected_lines=[{'level': 'DEBUG', 'text': 'hello debug'}])
+            {'level': 'ERROR', 'text': 'hello exception'}], \
+            not_expected_lines=[
+                {'level': 'DEBUG', 'text': 'hello debug'},
+                {'level': 'INFO', 'text': 'hello default info'},
+                {'level': 'INFO', 'text': 'hello info'}])


### PR DESCRIPTION
- Log format for Syslog is now RFC5424-compliant.
- Log format for app.log changes:
    - module and funcName removed (redundant because was always log_qpylib.log)
    - app ID and notification code added.
- log() no longer needs to add app ID and notification code to the message body.
- log() and set_log_level() now raise ValueError if level is invalid.
- create_log() now raises ValueError if the threshold log level in the manifest is invalid.
- set_log_level() now raises RuntimeError if logging has not been initialised.
- Mapping objects in log_qpylib are initialised once only.
- SysLogHandler is added only if env variables QRADAR_CONSOLE_IP and QRADAR_APP_UUID are set.