### PR TITLE
Auto documenting with pdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist
 qpylib.egg-info
 qpylib/version.py
 RemoteSystemsTempFiles
+docs

--- a/.pdoc_templates/config.mako
+++ b/.pdoc_templates/config.mako
@@ -1,0 +1,42 @@
+<%!
+    # Template configuration. Copy over in your template directory
+    # (used with `--template-dir`) and adapt as necessary.
+    # Note, defaults are loaded from this distribution file, so your
+    # config.mako only needs to contain values you want overridden.
+    # You can also run pdoc with `--config KEY=VALUE` to override
+    # individual values.
+    html_lang = 'en'
+    show_inherited_members = False
+    extract_module_toc_into_sidebar = True
+    list_class_variables_in_index = True
+    sort_identifiers = False
+    show_type_annotations = True
+    # Show collapsed source code block next to each item.
+    # Disabling this can improve rendering speed of large modules.
+    show_source_code = True
+    # If set, format links to objects in online source code repository
+    # according to this template. Supported keywords for interpolation
+    # are: commit, path, start_line, end_line.
+    git_link_template = 'https://github.com/IBM/qpylib/blob/{commit}/{path}#L{start_line}-L{end_line}'
+    # A prefix to use for every HTML hyperlink in the generated documentation.
+    # No prefix results in all links being relative.
+    link_prefix = ''
+    # Enable syntax highlighting for code/source blocks by including Highlight.js
+    syntax_highlighting = True
+    # Set the style keyword such as 'atom-one-light' or 'github-gist'
+    #     Options: https://github.com/highlightjs/highlight.js/tree/master/src/styles
+    #     Demo: https://highlightjs.org/static/demo/
+    hljs_style = 'foundation'
+    # Enable offline search using Lunr.js. For explanation of 'fuzziness' parameter, which is
+    # added to every query word, see: https://lunrjs.com/guides/searching.html#fuzzy-matches
+    # If 'index_docstrings' is False, a shorter index is built, indexing only
+    # the full object reference names.
+    lunr_search = {'fuzziness': 1, 'index_docstrings': True}
+    # lunr_search = None
+    # If set, render LaTeX math syntax within \(...\) (inline equations),
+    # or within \[...\] or $$...$$ or `.. math::` (block equations)
+    # as nicely-formatted math formulas using MathJax.
+    # Note: in Python docstrings, either all backslashes need to be escaped (\\)
+    # or you need to use raw r-strings.
+    latex_math = False
+%>

--- a/.pdoc_templates/credits.mako
+++ b/.pdoc_templates/credits.mako
@@ -1,0 +1,1 @@
+<span>This software is licensed under the <a href="https://github.com/IBM/qpylib/blob/master/LICENSE">Apache License 2.0</a></span>

--- a/.pdoc_templates/head.mako
+++ b/.pdoc_templates/head.mako
@@ -1,0 +1,25 @@
+<%!
+    from pdoc.html_helpers import minify_css
+%>
+<%def name="homelink()" filter="minify_css">
+    .homelink {
+        display: block;
+        font-size: 2em;
+        font-weight: bold;
+        color: #555;
+        padding-bottom: .5em;
+        border-bottom: 1px solid silver;
+    }
+    .homelink:hover {
+        color: inherit;
+    }
+    .homelink img {
+        max-width:20%;
+        max-height: 5em;
+        margin: auto;
+        margin-bottom: .3em;
+    }
+</%def>
+
+<link rel="canonical" href="https://pdoc3.github.io/pdoc/doc/${module.url()[:-len('index.html')] if module.is_package else module.url()}">
+<style>${homelink()}</style>

--- a/.pdoc_templates/logo.mako
+++ b/.pdoc_templates/logo.mako
@@ -1,0 +1,5 @@
+<header>
+    <a class="homelink" rel="home" title="QRadar App Python Library (qpylib)" href="Link to the hosted documentation website">
+        qpylib
+    </a>
+</header>

--- a/pdoc.sh
+++ b/pdoc.sh
@@ -2,9 +2,32 @@
 # Copyright 2019 IBM Corporation All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 # Generating documentation programatically
 docs_folder="docs"
 python3 -m pdoc qpylib --output-dir ./${docs_folder} --html --force --template-dir ./.pdoc_templates
 
-# Then publish the documentation to github.io website for exemple
+echo "[SUCCESS] Documentation generated under ./${docs_folder}"
+
+# Then publish the documentation to github.io website 
+docs_user="tristanlatr" # To change
+docs_repo="qpylib-docs-testing" # To change
+
+github_site="https://github.com/${docs_user}/${docs_repo}.git"
+
+# Ask to publish
+read -p "[QUESTION] Do you want to publish the documentation? [y/n]" -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    rm -rf "./${docs_repo}"
+    git clone "${github_site}"
+    rm -rf "./${docs_repo}/*"
+    cp -R "./${docs_folder}/qpylib/" "./${docs_repo}/"
+    cd "${docs_repo}"
+    git add .
+    git commit -m "Generate ${keyword} docs $(date)" --quiet
+    git push origin master --quiet
+
+    echo "[SUCCESS] Documentation published: https://${docs_user}.github.io/${docs_repo}"
+fi

--- a/pdoc.sh
+++ b/pdoc.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright 2019 IBM Corporation All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Generating documentation programatically
+docs_folder="docs"
+python3 -m pdoc qpylib --output-dir ./${docs_folder} --html --force --template-dir ./.pdoc_templates
+
+# Then publish the documentation to github.io website for exemple

--- a/qpylib/__init__.py
+++ b/qpylib/__init__.py
@@ -1,6 +1,9 @@
 # Copyright 2019 IBM Corporation All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+"""
+Welcome to the **qpylib** documentation. 
+"""
 
 __author__ = 'IBM'
 __version__ = 'unknown'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ responses
 pylint==2.5.3
 pytest==5.4.3
 pytest-cov==2.10.0
+pdoc3


### PR DESCRIPTION
Hello,

In this PR you will find a new script `pdoc.sh` that generates the library HTML documentation based on docstrings.
The script also publish the files to a GitHub.io site of your choice (some variables need to be changed).

Then it looks like this: https://tristanlatr.github.io/qpylib-docs-testing/
It's really helpful to quickly find the most relevant objects in the library. 
It still lack a few usage example tho.

Hope it helps